### PR TITLE
basic support for password protected (ZipCrypto) zip files

### DIFF
--- a/SharpFileSystem.SharpZipLib/SharpZipLibFileSystem.cs
+++ b/SharpFileSystem.SharpZipLib/SharpZipLibFileSystem.cs
@@ -16,9 +16,21 @@ namespace SharpFileSystem.SharpZipLib
             return new SharpZipLibFileSystem(new ZipFile(s));
         }
 
+        public static SharpZipLibFileSystem Open(Stream s,string password)
+        {
+            return new SharpZipLibFileSystem(new ZipFile(s){Password = password});
+        }
+
         public static SharpZipLibFileSystem Create(Stream s)
         {
             return new SharpZipLibFileSystem(ZipFile.Create(s));
+        }
+
+        public static SharpZipLibFileSystem Create(Stream s,string password)
+        {
+            var zipFile = ZipFile.Create(s);
+            zipFile.Password = password;
+            return new SharpZipLibFileSystem(zipFile);
         }
 
         private SharpZipLibFileSystem(ZipFile zipFile)

--- a/SharpFileSystem.Tests/SharpFileSystem.Tests.csproj
+++ b/SharpFileSystem.Tests/SharpFileSystem.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -44,6 +44,7 @@
     <Compile Include="FileSystems\MemoryFileSystemTest.cs" />
     <Compile Include="FileSystems\PhysicalFileSystemTest.cs" />
     <Compile Include="SharpZipLib\SharpZipLibFileSystemTest.cs" />
+    <Compile Include="SharpZipLib\SharpZipLibFileSystemWithPasswordTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SharpFileSystem.Tests/SharpFileSystem.Tests.csproj
+++ b/SharpFileSystem.Tests/SharpFileSystem.Tests.csproj
@@ -72,5 +72,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/SharpFileSystem.Tests/SharpZipLib/SharpZipLibFileSystemWithPasswordTest.cs
+++ b/SharpFileSystem.Tests/SharpZipLib/SharpZipLibFileSystemWithPasswordTest.cs
@@ -57,7 +57,6 @@ namespace SharpFileSystem.Tests.SharpZipLib
 
         private readonly FileSystemPath directoryPath = FileSystemPath.Parse("/directory/");
         private readonly FileSystemPath textfileAPath = FileSystemPath.Parse("/textfileA.txt");
-        private readonly FileSystemPath zipfileAPath = FileSystemPath.Parse("/internalzip.zip");
         private readonly FileSystemPath fileInDirectoryPath = FileSystemPath.Parse("/directory/fileInDirectory.txt");
         
         [Test]

--- a/SharpFileSystem.Tests/SharpZipLib/SharpZipLibFileSystemWithPasswordTest.cs
+++ b/SharpFileSystem.Tests/SharpZipLib/SharpZipLibFileSystemWithPasswordTest.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using ICSharpCode.SharpZipLib.Zip;
+using NUnit.Framework;
+using SharpFileSystem.IO;
+using SharpFileSystem.SharpZipLib;
+
+namespace SharpFileSystem.Tests.SharpZipLib
+{
+    [TestFixture]
+    public class SharpZipLibFileSystemWithPasswordTest
+    {
+        private Stream zipStream;
+        private SharpZipLibFileSystem fileSystem;
+        private SharpZipLibFileSystem badFileSystem;
+        private readonly string zipPassword = "unittestpassword";
+        private readonly string fileContent = "this is a file";
+        [OneTimeSetUp]
+        public void Initialize()
+        {
+            CreateInitialZipStream();
+            fileSystem = SharpZipLibFileSystem.Open(zipStream,zipPassword);
+            badFileSystem = SharpZipLibFileSystem.Open(zipStream, "wrongpassword");
+        }
+
+        private void CreateInitialZipStream()
+        {
+            var memoryStream = new MemoryStream();
+            zipStream = memoryStream;
+            var zipOutput = new ZipOutputStream(zipStream);
+            zipOutput.Password = zipPassword;
+
+            var fileContentString = fileContent;
+            var fileContentBytes = Encoding.ASCII.GetBytes(fileContentString);
+            zipOutput.PutNextEntry(new ZipEntry("textfileA.txt")
+            {
+                Size = fileContentBytes.Length
+            });
+            zipOutput.Write(fileContentBytes);
+            zipOutput.PutNextEntry(new ZipEntry("directory/fileInDirectory.txt"));
+            zipOutput.Finish();
+
+            memoryStream.Position = 0;
+
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            fileSystem.Dispose();
+            badFileSystem.Dispose();
+            zipStream.Dispose();
+        }
+
+        private readonly FileSystemPath directoryPath = FileSystemPath.Parse("/directory/");
+        private readonly FileSystemPath textfileAPath = FileSystemPath.Parse("/textfileA.txt");
+        private readonly FileSystemPath zipfileAPath = FileSystemPath.Parse("/internalzip.zip");
+        private readonly FileSystemPath fileInDirectoryPath = FileSystemPath.Parse("/directory/fileInDirectory.txt");
+        
+        [Test]
+        public void GetEntitiesOfRootTest()
+        {
+            CollectionAssert.AreEquivalent(new[]
+            {
+                textfileAPath,
+                directoryPath
+            }, fileSystem.GetEntities(FileSystemPath.Root).ToArray());
+        }
+
+        [Test]
+        public void GetEntitiesOfDirectoryTest()
+        {
+            CollectionAssert.AreEquivalent(new[]
+            {
+                fileInDirectoryPath
+            }, fileSystem.GetEntities(directoryPath).ToArray());
+        }
+
+        [Test]
+        public void ExistsTest()
+        {
+            Assert.IsTrue(fileSystem.Exists(FileSystemPath.Root));
+            Assert.IsTrue(fileSystem.Exists(textfileAPath));
+            Assert.IsTrue(fileSystem.Exists(directoryPath));
+            Assert.IsTrue(fileSystem.Exists(fileInDirectoryPath));
+            Assert.IsFalse(fileSystem.Exists(FileSystemPath.Parse("/nonExistingFile")));
+            Assert.IsFalse(fileSystem.Exists(FileSystemPath.Parse("/nonExistingDirectory/")));
+            Assert.IsFalse(fileSystem.Exists(FileSystemPath.Parse("/directory/nonExistingFileInDirectory")));
+        }
+
+        [Test]
+        public void CanOpenFileWithCorrectPassword()
+        {
+            var fs = fileSystem.OpenFile(textfileAPath, FileAccess.Read);
+            Assert.AreEqual(fs.ReadAllText(), fileContent);
+        }
+
+        [Test]
+        public void OpenFileThrowsZipExceptiontWithIncorrectPassword()
+        {
+            Assert.Throws<ZipException>( () =>
+            {
+                badFileSystem.OpenFile(textfileAPath, FileAccess.Read);
+            });
+        }
+    }
+}


### PR DESCRIPTION
added overloads for SharpFileSystem.Open and .Create to take a password for the zip file
re-used unit tests from SharpFileSystemTests as well as added unit tests to verify that a file can be opened when the correct password is in use, and that  an exception is thrown when trying to open a file with the wrong password.
